### PR TITLE
Delay prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+*.sw*

--- a/example/App.vue
+++ b/example/App.vue
@@ -13,7 +13,7 @@
     </header>
     <div class="main-content">
       <div class="transition-wrapper" :class="{group: isGroup}">
-        <component :is="kebab(transitionName)" :duration="duration" appear v-if="!isGroup">
+        <component :is="kebab(transitionName)" :duration="duration" :delay="delay" appear v-if="!isGroup">
           <div v-show="show">
             <div class="box">
               <p>{{transitionName}}</p>
@@ -22,7 +22,7 @@
         </component>
         <div class="transition-group-wrapper" v-else>
           <div>
-            <component :is="kebab(transitionName)" group :duration="duration">
+            <component :is="kebab(transitionName)" group :duration="duration" :delay="delay">
               <Icon v-for="(color,index) in colors" :color="color"
                     :key="color.key"
                     :index="index"
@@ -52,12 +52,21 @@
           <button class="btn btn-outline" v-tippy="{interactive: true}" :title="example">Code</button>
         </div>
         <div class="transition-settings">
-          <el-input-number :step="100" v-model="duration" placeholder="Duration"></el-input-number>
-          <el-switch
-            v-model="isGroup"
-            active-text="Group"
-            inactive-text="Simple">
-          </el-switch>
+          <div class="transition-settings_setting">
+            Duration
+            <el-input-number :step="100" v-model="duration" placeholder="Duration"></el-input-number>
+          </div>
+          <div class="transition-settings_setting">
+            Delay
+            <el-input-number :step="100" v-model="delay" placeholder="Delay"></el-input-number>
+          </div>
+          <div class="transition-settings_setting">
+            <el-switch
+              v-model="isGroup"
+              active-text="Group"
+              inactive-text="Simple">
+            </el-switch>
+          </div>
         </div>
       </div>
 
@@ -126,6 +135,7 @@
         show: true,
         isGroup: false,
         duration: 300,
+        delay: 0,
         transitionName: 'FadeTransition'
       }
     },
@@ -134,13 +144,22 @@
         let sampleCode = example
           .replace(/TRANSITION/g, this.transitionName)
           .replace(/kebab-transition/g, kebab(this.transitionName))
-        if (!this.isGroup) {
-          sampleCode = sampleCode.replace(/group/g, '')
-        }
-        if (this.duration !== 300) {
-          sampleCode = sampleCode.replace(/duration/g, `:duration="${this.duration}"`)
+        if (this.isGroup) {
+          sampleCode = sampleCode.replace(/\[group\]/g, '')
         } else {
-          sampleCode = sampleCode.replace(/duration/g, '')
+          sampleCode = sampleCode.replace(/\[group\]/g, ' group')
+        }
+
+        if (this.duration !== 300) {
+          sampleCode = sampleCode.replace(/\[duration\]/g, ` :duration="${this.duration}"`)
+        } else {
+          sampleCode = sampleCode.replace(/\[duration\]/g, '')
+        }
+
+        if (this.delay !== 0) {
+          sampleCode = sampleCode.replace(/\[delay\]/g, ` :delay="${this.delay}"`)
+        } else {
+          sampleCode = sampleCode.replace(/\[delay\]/g, '')
         }
         return sampleCode
       }
@@ -273,9 +292,19 @@
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
+
     .el-switch {
-      margin-left: 20px;
       margin-top: 10px;
+    }
+
+    &_setting {
+      display: flex;
+      flex-direction: column;
+      margin-left: 20px;
+
+      .el-input-number {
+        margin-top: 10px;
+      }
     }
   }
 
@@ -315,6 +344,10 @@
       margin-top: 0;
       .el-switch {
         margin-right: 0;
+      }
+      &_setting {
+        margin-left: 0px;
+        margin-bottom: 10px;
       }
     }
     .transition-select {

--- a/example/example.md
+++ b/example/example.md
@@ -1,6 +1,6 @@
 ```vue
 <template>
-  <kebab-transition group duration>
+  <kebab-transition[group][duration][delay]>
     <div v-show="show">Your content here</div> 
   </kebab-transition>
 </template>

--- a/src/mixins/baseTransition.js
+++ b/src/mixins/baseTransition.js
@@ -59,7 +59,7 @@ export default {
   methods: {
     beforeEnter(el) {
       let enterDuration = this.duration.enter ? this.duration.enter : this.duration
-      el.style.animationDuration = `${enterDuration / 1000}s`
+      el.style.animationDuration = `${enterDuration}ms`
       this.setStyles(el)
     },
     cleanUpStyles(el) {
@@ -73,7 +73,7 @@ export default {
     },
     beforeLeave(el) {
       let leaveDuration = this.duration.leave ? this.duration.leave : this.duration
-      el.style.animationDuration = `${leaveDuration / 1000}s`
+      el.style.animationDuration = `${leaveDuration}ms`
       this.setStyles(el)
     },
     leave(el) {

--- a/src/mixins/baseTransition.js
+++ b/src/mixins/baseTransition.js
@@ -10,6 +10,14 @@ export default {
       default: 300
     },
     /**
+     * Transition delay. Number for specifying the same delay for enter/leave transitions
+     * Object style {enter: 300, leave: 300} for specifying explicit durations for enter/leave
+     */
+    delay: {
+      type: [Number, Object],
+      default: 0
+    },
+    /**
      * Whether the component should be a `transition-group` component.
      */
     group: Boolean,
@@ -60,6 +68,10 @@ export default {
     beforeEnter(el) {
       let enterDuration = this.duration.enter ? this.duration.enter : this.duration
       el.style.animationDuration = `${enterDuration}ms`
+
+      let enterDelay = this.delay.enter ? this.delay.enter : this.delay
+      el.style.animationDelay = `${enterDelay}ms`
+
       this.setStyles(el)
     },
     cleanUpStyles(el) {
@@ -70,10 +82,15 @@ export default {
         }
       })
       el.style.animationDuration = ''
+      el.style.animationDelay = ''
     },
     beforeLeave(el) {
       let leaveDuration = this.duration.leave ? this.duration.leave : this.duration
       el.style.animationDuration = `${leaveDuration}ms`
+
+      let leaveDelay = this.delay.leave ? this.delay.leave : this.delay
+      el.style.animationDelay = `${leaveDelay}ms`
+
       this.setStyles(el)
     },
     leave(el) {


### PR DESCRIPTION
Added new `delay` prop to the mixin.

This is useful for composing transitions.

E.g.

```vue
<FadeTransition :duration="300">
   <Card>
        <ZoomYTransition :delay="300">
            <BigSecret />
        </ZoomYTransition>
   </Card>
</Fade>
```

Then we can make sure the `<BigSecret>` shows right after the `Card` fades in.

🍻 🍻 🍻 