### PR TITLE
Flip the logic for code example's group prop

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -144,7 +144,7 @@
         let sampleCode = example
           .replace(/TRANSITION/g, this.transitionName)
           .replace(/kebab-transition/g, kebab(this.transitionName))
-        if (this.isGroup) {
+        if (!this.isGroup) {
           sampleCode = sampleCode.replace(/\[group\]/g, '')
         } else {
           sampleCode = sampleCode.replace(/\[group\]/g, ' group')


### PR DESCRIPTION
At the moment when the `isGroup` `el-switch` is in its default state ("Simple"), it adds the boolean `group` prop to the code example and removes it when the switch is toggled to "Group".